### PR TITLE
Add basic frontend support for authorization

### DIFF
--- a/portfolio/src/main/webapp/css/master.css
+++ b/portfolio/src/main/webapp/css/master.css
@@ -20,6 +20,14 @@
   z-index: 10;
 }
 
+.only-display-with-auth {
+  display: none;
+}
+
+.only-display-without-auth {
+  display: none;
+}
+
 .project-card {
   transition: 0.1s;
 }

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -159,7 +159,15 @@
 
       <h3>Comments</h3>
       <div id="comment-section" class="mt-4 mb-5">
-        <div class="card p-4 mb-2">
+        <div class="only-display-without-auth card p-4 mb-2">
+          <div class="row justify-content-center">
+            <h4>Please login to post a comment.</h4>
+          </div>
+          <div class="row justify-content-center">
+            <a id="comment-auth-login" class="text-center btn btn-success" href="#" role="button">Login</a>
+          </div>
+        </div>
+        <div class="only-display-with-auth card p-4 mb-2">
           <h4 class="text-center">Post your thoughts!</h4>
           <form id="comment-form" action="/comments" method="POST">
             <div class="form-group">

--- a/portfolio/src/main/webapp/js/comments.js
+++ b/portfolio/src/main/webapp/js/comments.js
@@ -59,6 +59,7 @@ function applyAuthorizationToUI() {
  * @property {boolean} authorized Whether the user is currently authorized.
  * @property {{string: email, string: id}} [user] Information about the 
  * current authorized user. Only present if the user is authorized.
+ */
 /**
  * Gets the user's authorization status.
  * @return {Promise} Returns a promise that fetches the user's 

--- a/portfolio/src/main/webapp/js/comments.js
+++ b/portfolio/src/main/webapp/js/comments.js
@@ -70,14 +70,7 @@ function applyAuthorizationToUI() {
  * authorization data {@link AuthData}.
  */
 function getAuthorization() {
-  return fetch('/auth').then((resp) => {
-    if (resp.ok) {
-      return resp.json();
-    } else {
-      return resp.text().then(
-          text => Promise.reject(`Error ${resp.status}: ${text}`));
-    }
-  }).then((authData) => {
+  return formatFetchResponse(fetch('/auth')).then((authData) => {
     console.log("Got comment authorization:");
     console.log(authData);
     commentAuthData = authData;
@@ -97,14 +90,7 @@ function loadComments() {
   loadUrl.searchParams.set(
       "page", commentControl.elements["pageNum"].value)
 
-  fetch(loadUrl).then(resp => {
-    if (resp.ok) {
-      return resp.json();
-    } else {
-      return resp.text().then(
-          text => Promise.reject(`Error ${resp.status}: ${text}`));
-    }
-  }).then(comments => {
+  formatFetchResponse(fetch(loadUrl)).then(comments => {
     console.log("Received comments: ");
     console.log(comments);
 
@@ -189,14 +175,9 @@ function postComment(event) {
     body: formData
   };
 
-  fetch('/comments', requestOptions).then(resp => {
-    if (resp.ok) {
-      addNotification("Comment posted successfully!", "alert-success");
-      loadComments();
-    } else {
-      return resp.text().then(
-          text => Promise.reject(`Error ${resp.status}: ${text}`));
-    }
+  formatFetchResponse(fetch('/comments', requestOptions)).then(() => {
+    addNotification("Comment posted successfully!", "alert-success");
+    loadComments();
   }).catch(err => {
     console.error(err);
 
@@ -217,20 +198,34 @@ function createCommentDeleter(id) {
         new URL("/comments", `${location.protocol}//${location.hostname}`);
     deleteUrl.searchParams.set("id", id);
 
-    fetch(deleteUrl, { method: 'DELETE' }).then((resp) => {
-        if (resp.ok) {
-          addNotification("Comment deleted successfully.", "alert-success");
-          loadComments();
-        } else {
-          return resp.text().then(
-              text => Promise.reject(`Error ${resp.status}: ${text}`));
-        }
-      }).catch(err => {
+    formatFetchResponse(fetch(deleteUrl, { method: 'DELETE' })).then(() => {
+      addNotification("Comment deleted successfully.", "alert-success");
+      loadComments();
+    }).catch(err => {
         console.log(err);
 
         addNotification(
           "Failed to delete the comment! Please try again later.", 
           "alert-danger");
-      });
+    });
   };
+}
+
+/**
+ * Formats the fetch response according to the portfolio's API.
+ * 
+ * If the response is okay, the response format is JSON. Otherwise the error 
+ * message is formatted as raw text and the promise is rejected.
+ * @param {Promise} fetchRequest Fetch request to portfolio API.
+ * @return {Promise}
+ */
+function formatFetchResponse(fetchRequest) {
+  return fetch.then((resp) => {
+    if (resp.ok) {
+      return resp.json();
+    } else {
+      return resp.text().then(
+          text => Promise.reject(`Error ${resp.status}: ${text}`));
+    }
+  });
 }

--- a/portfolio/src/main/webapp/js/comments.js
+++ b/portfolio/src/main/webapp/js/comments.js
@@ -54,7 +54,15 @@ function applyAuthorizationToUI() {
 }
 
 /**
+ * @typedef {Object} AuthData
+ * @property {string} loginUrl The URL to log in.
+ * @property {boolean} authorized Whether the user is currently authorized.
+ * @property {{string: email, string: id}} [user] Information about the 
+ * current authorized user. Only present if the user is authorized.
+/**
  * Gets the user's authorization status.
+ * @return {Promise} Returns a promise that fetches the user's 
+ * authorization data {@link AuthData}.
  */
 function getAuthorization() {
   return fetch('/auth').then((resp) => {

--- a/portfolio/src/main/webapp/js/comments.js
+++ b/portfolio/src/main/webapp/js/comments.js
@@ -1,4 +1,15 @@
+/**
+ * @typedef {Object} AuthData
+ * @property {string} loginUrl The URL to log in.
+ * @property {boolean} authorized Whether the user is currently authorized.
+ * @property {{string: email, string: id}} [user] Information about the 
+ * current authorized user. Only present if the user is authorized.
+ */
+/**
+ * @type {AuthData}
+ */
 let commentAuthData = null;
+
 /**
  * Initializes the comment system.
  */
@@ -53,13 +64,6 @@ function applyAuthorizationToUI() {
   }
 }
 
-/**
- * @typedef {Object} AuthData
- * @property {string} loginUrl The URL to log in.
- * @property {boolean} authorized Whether the user is currently authorized.
- * @property {{string: email, string: id}} [user] Information about the 
- * current authorized user. Only present if the user is authorized.
- */
 /**
  * Gets the user's authorization status.
  * @return {Promise} Returns a promise that fetches the user's 

--- a/portfolio/src/main/webapp/js/comments.js
+++ b/portfolio/src/main/webapp/js/comments.js
@@ -40,10 +40,12 @@ function applyAuthorizationToUI() {
   if (commentAuthData.authorized) {
     const withAuthElements = 
         Array.from(document.getElementsByClassName("only-display-with-auth"));
+    // Make authorization-only UI visible
     withAuthElements.forEach((elem) => elem.style.display = "inherit");
   } else {
     const withoutAuthElements = Array.from(
         document.getElementsByClassName("only-display-without-auth"));
+    // Make no-authorization-only UI visible
     withoutAuthElements.forEach((elem) => elem.style.display = "inherit");
     
     const loginButton = document.getElementById("comment-auth-login");


### PR DESCRIPTION
Adds basic frontend support for authorization that:
* Displays a login element/notification for a user that is not currently logged in
* Displays the comment-posting form if the user is authenticated



It is important to note that there is no backend support for authentication in the comments system yet beyond the authentication system itself. This means that even if the frontend is restricted based on the authentication status of the user, the user could still interact with the website through the API.