### PR TITLE
Add testing and functionality for optional attendees in meeting request query

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -19,33 +19,59 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public final class FindMeetingQuery {
   /**
    * Get the collection of time ranges when an event can be held.
+   *
+   * If time ranges are available with optional attendees, those ranges are returned.
+   * Otherwise, the time ranges when required attendees are available are returned.
    * @param events
    * @param request
    * @return Returns the collection of time ranges when the event can be held.
    */
-  public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
+  public Collection<TimeRange> query(
+      Collection<Event> events, MeetingRequest request) {
     if (request.getDuration() > TimeRange.WHOLE_DAY.duration()) {
       return Arrays.asList();
     }
 
-    Collection<TimeRange> validTimeRanges = new ArrayList<TimeRange>();
+    Collection<String> attendees = request.getAttendees();
+    Collection<String> optionalAttendees = request.getOptionalAttendees();
+    Collection<String> allAttendees = 
+        Stream.concat(attendees.stream(), optionalAttendees.stream()).collect(Collectors.toList());
+    
+    Collection<TimeRange> rangesAvailableAllAttendees =
+        getRangesWithoutConflict(events, allAttendees, request.getDuration());
+    
+    // First check for time ranges available with all attendees.
+    if (!rangesAvailableAllAttendees.isEmpty() || 
+        attendees.isEmpty() || 
+        optionalAttendees.isEmpty()) {
+      // If required attendees is empty: treat optional attendees as required.
+      // If optional attendees is empty: no need to check for times without optional attendees.
+      return rangesAvailableAllAttendees;
+    }
 
-    Collection<TimeRange> orderedConflicts = 
-        getOrderedAttendingEvents(events, request.getAttendees());
-    Iterator<TimeRange> conflictsIterator = orderedConflicts.iterator();
+
+    return getRangesWithoutConflict(events, attendees, request.getDuration());
+  }
+
+  private Collection<TimeRange> getRangesWithoutConflict(
+      Collection<Event> events, Collection<String> attendees, long rangeDuration) {
+    Iterator<TimeRange> conflictsIterator = getOrderedAttendingEvents(events, attendees).iterator();
+    
     int prevConflictEndTime = TimeRange.START_OF_DAY;
-
+    Collection<TimeRange> validTimeRanges = new ArrayList<TimeRange>();
     while (conflictsIterator.hasNext()) {
       TimeRange conflict = conflictsIterator.next();
       int conflictStartTime = conflict.start();
       
       // Check for gap between prev conflict and this conflict.
       if (conflictStartTime > prevConflictEndTime && 
-          conflictStartTime - prevConflictEndTime >= request.getDuration()) {
+          conflictStartTime - prevConflictEndTime >= rangeDuration) {
         validTimeRanges.add(TimeRange.fromStartEnd(prevConflictEndTime, conflictStartTime, false));
       }
 
@@ -56,7 +82,7 @@ public final class FindMeetingQuery {
       }
     }
 
-    if (TimeRange.END_OF_DAY - prevConflictEndTime >= request.getDuration()) {
+    if (TimeRange.END_OF_DAY - prevConflictEndTime >= rangeDuration) {
       validTimeRanges.add(TimeRange.fromStartEnd(prevConflictEndTime, TimeRange.END_OF_DAY, true));  
     }
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -45,7 +45,6 @@ public final class FindMeetingQuery {
     Collection<TimeRange> rangesAvailableAllAttendees =
         getRangesWithoutConflict(events, allAttendees, request.getDuration());
     
-    // First check for time ranges available with all attendees.
     if (!rangesAvailableAllAttendees.isEmpty() || 
         attendees.isEmpty() || 
         optionalAttendees.isEmpty()) {

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -14,10 +14,140 @@
 
 package com.google.sps;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
 
 public final class FindMeetingQuery {
+  /**
+   * Get the collection of time ranges when an event can be held.
+   * @param events
+   * @param request
+   * @return Returns the collection of time ranges when the event can be held.
+   */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    throw new UnsupportedOperationException("TODO: Implement this method.");
+    if (request.getDuration() > TimeRange.WHOLE_DAY.duration()) {
+      return Arrays.asList();
+    }
+
+    events = getEventsAttending(events, request.getAttendees());
+    Collection<TimeRange> availableTimes = new ArrayList<TimeRange>();
+    availableTimes.add(TimeRange.WHOLE_DAY);
+
+    // Each event time range punches a hole in available time range
+    Iterator<Event> eventIterator = events.iterator();
+    Event event;
+    while (eventIterator.hasNext()) {
+      event = eventIterator.next();
+      TimeRange eventTimeRange = event.getWhen();
+
+      Collection<TimeRange> newRanges = new ArrayList<TimeRange>();
+      Collection<TimeRange> rangesToRemove = new ArrayList<TimeRange>();
+      Iterator<TimeRange> availableTimesIterator = availableTimes.iterator();
+      TimeRange availableTime;
+      while (availableTimesIterator.hasNext()) {
+        availableTime = availableTimesIterator.next();
+
+        if (availableTime.overlaps(eventTimeRange)) {
+          removeRange(
+              newRanges, rangesToRemove, availableTime, eventTimeRange, request.getDuration());
+        }
+      }
+
+      availableTimes.removeAll(rangesToRemove);
+      availableTimes.addAll(newRanges);
+    }
+
+    return availableTimes;
+  }
+
+  /**
+   * Removes a range of time from a time range.
+   * Precondition: The ranges are assumed to be overlapping.
+   *
+   * Broken down into three different scenarios:
+   * 1. The time range is fully contained in the range to remove: just remove the time range.
+   * 2. The range to remove is fully contained in the time range: split the time range into two
+   * pieces.
+   * 3. The time range overlaps with the range to remove but neither is fully contained in the
+   * other: trim the time range.
+   * 
+   * @param newRanges
+   * @param discardedRanges
+   * @param timeRange
+   * @param rangeToRemove
+   * @param minDuration
+   */
+  private void removeRange(
+      Collection<TimeRange> newRanges,
+      Collection<TimeRange> discardedRanges,
+      TimeRange timeRange, 
+      TimeRange rangeToRemove, 
+      long minDuration) {
+    discardedRanges.add(timeRange);
+    if (rangeToRemove.contains(timeRange)) {
+      return;
+    }
+    
+    if (timeRange.contains(rangeToRemove)) {
+      // Split time
+      addTimeRangeIfLongEnough(newRanges, timeRange.start(), rangeToRemove.start(), minDuration);
+      addTimeRangeIfLongEnough(newRanges, rangeToRemove.end(), timeRange.end(), minDuration);
+    }
+    else {
+      if (timeRange.start() < rangeToRemove.start()) {
+        addTimeRangeIfLongEnough(
+            newRanges, timeRange.start(), rangeToRemove.start(), minDuration);
+      } else {
+        addTimeRangeIfLongEnough(newRanges, rangeToRemove.end(), timeRange.end(), minDuration);
+      }
+    }
+  }
+
+  /**
+   * Adds a time range to the collection if it meets the specified minimum duration
+   * @param newRanges
+   * @param startTime
+   * @param endTime
+   * @param minDuration
+   */
+  private void addTimeRangeIfLongEnough(
+      Collection<TimeRange> newRanges, int startTime, int endTime, long minDuration) {
+    if (endTime - startTime >= minDuration) {
+      newRanges.add(TimeRange.fromStartEnd(startTime, endTime, false));
+    }
+  }
+
+  /**
+   * Gets all of the events being attended by at least one of the attendees.
+   * @param events
+   * @param attendees
+   * @return Returns a collection of events being attended by at least one of the attendees.
+   */
+  private Collection<Event> getEventsAttending(
+      Collection<Event> events, Collection<String> attendees) {
+    Collection<Event> attendingEvents = new ArrayList<Event>();
+
+    Iterator<Event> eventsIterator = events.iterator();
+    Event event;
+    while (eventsIterator.hasNext()) {
+      event = eventsIterator.next();
+      Set<String> eventAttendees = event.getAttendees();
+
+      Iterator<String> attendeesIterator = attendees.iterator();
+      String attendee;
+      while (attendeesIterator.hasNext()) {
+        attendee = attendeesIterator.next();
+        
+        if (eventAttendees.contains(attendee)) {
+          attendingEvents.add(event);
+          break;
+        }
+      }
+    }
+
+    return attendingEvents;
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -32,8 +32,7 @@ public final class FindMeetingQuery {
    * @param request
    * @return Returns the collection of time ranges when the event can be held.
    */
-  public Collection<TimeRange> query(
-      Collection<Event> events, MeetingRequest request) {
+  public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     if (request.getDuration() > TimeRange.WHOLE_DAY.duration()) {
       return Arrays.asList();
     }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -17,6 +17,7 @@ package com.google.sps;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
 
@@ -134,17 +135,9 @@ public final class FindMeetingQuery {
     Event event;
     while (eventsIterator.hasNext()) {
       event = eventsIterator.next();
-      Set<String> eventAttendees = event.getAttendees();
 
-      Iterator<String> attendeesIterator = attendees.iterator();
-      String attendee;
-      while (attendeesIterator.hasNext()) {
-        attendee = attendeesIterator.next();
-        
-        if (eventAttendees.contains(attendee)) {
-          attendingEvents.add(event);
-          break;
-        }
+      if (!Collections.disjoint(event.getAttendees(), attendees)) {
+        attendingEvents.add(event);
       }
     }
 


### PR DESCRIPTION
Adds support for optional attendees in meeting requests. Includes optional attendees' conflicts in the possible time ranges if there are one or more time ranges available. Otherwise, includes only the required attendees' conflicts in the possible time ranges.