### PR TITLE
Add support for uploading images to comments system

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -42,8 +42,8 @@ public final class Comment {
     String commentAuthor = DataServlet.getParameter(request, AUTHOR_KEY, "");
     String commentBody = DataServlet.getParameter(request, BODY_KEY, "");
 
-    commentAuthor = commentAuthor.replaceAll(UNSAFE_CHARACTERS_REGEX, "");
-    commentBody = commentBody.replaceAll(UNSAFE_CHARACTERS_REGEX, "");
+    commentAuthor = commentAuthor.replaceAll(UNSAFE_CHARACTERS_REGEX, "").trim();
+    commentBody = commentBody.replaceAll(UNSAFE_CHARACTERS_REGEX, "").trim();
 
     String validationError = validateIncomingComment(commentAuthor, commentBody);
     if (validationError != null) {
@@ -62,10 +62,10 @@ public final class Comment {
     List<String> validationErrors = new ArrayList<String>();
     
     // Used in place of string.isBlank(), which is only available in Java 11
-    if (commentAuthor.length() == 0 || commentAuthor.chars().allMatch(Character::isWhitespace)) {
+    if (commentAuthor.length() == 0) {
       validationErrors.add("Please include a comment author (cannot be whitespace).");
     }
-    if (commentBody.length() == 0 || commentBody.chars().allMatch(Character::isWhitespace)) {
+    if (commentBody.length() == 0) {
       validationErrors.add("Please include a comment body (cannot be whitespace).");
     }
 

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -61,7 +61,6 @@ public final class Comment {
   private static String validateIncomingComment(String commentAuthor, String commentBody) {
     List<String> validationErrors = new ArrayList<String>();
     
-    // Used in place of string.isBlank(), which is only available in Java 11
     if (commentAuthor.length() == 0) {
       validationErrors.add("Please include a comment author (cannot be whitespace).");
     }

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -60,11 +60,12 @@ public final class Comment {
    */
   private static String validateIncomingComment(String commentAuthor, String commentBody) {
     List<String> validationErrors = new ArrayList<String>();
-
-    if (commentAuthor.isBlank()) {
+    
+    // Used in place of string.isBlank(), which is only available in Java 11
+    if (commentAuthor.length() == 0 || commentAuthor.chars().allMatch(Character::isWhitespace)) {
       validationErrors.add("Please include a comment author (cannot be whitespace).");
     }
-    if (commentBody.isBlank()) {
+    if (commentBody.length() == 0 || commentBody.chars().allMatch(Character::isWhitespace)) {
       validationErrors.add("Please include a comment body (cannot be whitespace).");
     }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/CommentBlobstoreServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/CommentBlobstoreServlet.java
@@ -26,9 +26,7 @@ import javax.servlet.http.HttpServletResponse;
 
 @WebServlet("/comment-blobstore")
 public class CommentBlobstoreServlet extends HttpServlet {
-
-  // Use constant redirect instead of client-supplied redirect URL 
-  // to avoid blobstore redirect spoofing.
+  
   public static String BLOBSTORE_URL_REDIRECT = "/comments";
 
   private Gson gson = new Gson();

--- a/portfolio/src/main/java/com/google/sps/servlets/CommentBlobstoreServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/CommentBlobstoreServlet.java
@@ -1,0 +1,49 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/comment-blobstore")
+public class CommentBlobstoreServlet extends HttpServlet {
+
+  // Use constant redirect instead of client-supplied redirect URL 
+  // to avoid blobstore redirect spoofing.
+  public static String BLOBSTORE_URL_REDIRECT = "/comments";
+
+  private Gson gson = new Gson();
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
+    String uploadUrl = blobstoreService.createUploadUrl(BLOBSTORE_URL_REDIRECT);
+
+    JsonObject responseObject = new JsonObject();
+    responseObject.addProperty("uploadUrl", uploadUrl);
+    responseObject.addProperty("redirectUrl", BLOBSTORE_URL_REDIRECT);
+
+    response.setStatus(HttpServletResponse.SC_OK);
+    response.setContentType("application/json;");
+    response.getWriter().println(gson.toJson(responseObject));
+  }
+}

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -186,7 +186,11 @@
               <label for="comment-body">Comment</label>
               <textarea class="form-control comment-input" name="comment-body" maxlength="120" required></textarea>
             </div>
-            <button class="btn btn-primary" type="submit">Post</button>
+            <div class="form-group">
+              <label for="comment-body">Add Image (optional)</label>
+              <input type="file" class="form-control-file" name="commentPicture" accept=".gif,.jpg,.png"></input>
+            </div>
+            <button class="btn btn-primary" type="submit" name="submit-button">Post</button>
           </form>
         </div>
         <div class="card p-4 mb-4">


### PR DESCRIPTION
1. Adds a servlet that supplies a blobstore upload URL for posting comments with images.
2. Adds frontend support for uploading an image to a valid blobstore URL.

*Using the Blobstore API required migrating to Java 8, which is why `string.isBlank()` was changed (it isn't present in Java 8)*

Todos:
* The backend should validate the uploaded image.
* The backend should add the image URL to the comments datastore.
* The backend should return the image URL with the post response.
* The frontend should display images along with comments.