### PR TITLE
Include attached image URL in comments datastore

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -16,6 +16,7 @@ package com.google.sps.data;
 
 import com.google.appengine.api.datastore.Entity;
 import com.google.sps.helper.ValidationResult;
+import com.google.sps.servlets.CommentBlobstoreServlet;
 import com.google.sps.servlets.DataServlet;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,6 +32,7 @@ public final class Comment {
   public static final String BODY_KEY = "comment-body";
   public static final String TIME_POSTED_KEY = "timePosted";
   public static final String POSTER_ID_KEY = "posterId";
+  public static final String ATTACHED_IMAGE_URL_KEY = "attachedImageUrl";
   
   /**
    * Get and validate a comment object from an incoming request.
@@ -49,7 +51,10 @@ public final class Comment {
     if (validationError != null) {
       return new ValidationResult<Comment>(validationError);
     } else {
-      Comment newComment = new Comment(commentAuthor, commentBody, posterId);
+      String attachedImageUrl = 
+          CommentBlobstoreServlet.getUploadedImageURL(request, "attachedImage");
+
+      Comment newComment = new Comment(commentAuthor, commentBody, posterId, attachedImageUrl);
       return new ValidationResult<Comment>(newComment);
     }
   }
@@ -81,18 +86,22 @@ public final class Comment {
   private long id;
   private final long timePosted;
   private final String posterId;
+  private final String attachedImageUrl;
 
   /**
     * Creates a new comment object.
     * @param author The author of the comment.
     * @param commentBody The text body of the comment.
+    * @param posterId The ID of the user that posted the comment.
+    * @param attachedImageUrl The URL to the image attached with the comment or null if no image.
     */
-  public Comment(String author, String commentBody, String posterId) {
+  public Comment(String author, String commentBody, String posterId, String attachedImageUrl) {
     this.author = author;
     this.commentBody = commentBody;
     this.id = -1;
     this.timePosted = System.currentTimeMillis();
     this.posterId = posterId;
+    this.attachedImageUrl = attachedImageUrl;
   }
   
   /**
@@ -105,6 +114,7 @@ public final class Comment {
     this.commentBody = (String) commentEntity.getProperty(BODY_KEY);
     this.timePosted = (long) commentEntity.getProperty(TIME_POSTED_KEY);
     this.posterId = (String) commentEntity.getProperty(POSTER_ID_KEY);
+    this.attachedImageUrl = (String) commentEntity.getProperty(ATTACHED_IMAGE_URL_KEY);
   }
 
   /**
@@ -116,6 +126,7 @@ public final class Comment {
     commentEntity.setProperty(BODY_KEY, commentBody);
     commentEntity.setProperty(TIME_POSTED_KEY, timePosted);
     commentEntity.setProperty(POSTER_ID_KEY, posterId);
+    commentEntity.setProperty(ATTACHED_IMAGE_URL_KEY, attachedImageUrl);
   }
 
   public String getAuthor() {
@@ -136,6 +147,10 @@ public final class Comment {
 
   public long getTimePosted() {
     return timePosted;
+  }
+
+  public String getAttachedImageUrl() {
+    return attachedImageUrl;
   }
 
   public void setId(long id) {

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -42,8 +42,8 @@ public final class Comment {
     String commentAuthor = DataServlet.getParameter(request, AUTHOR_KEY, "");
     String commentBody = DataServlet.getParameter(request, BODY_KEY, "");
 
-    commentAuthor = commentAuthor.replaceAll(UNSAFE_CHARACTERS_REGEX, "");
-    commentBody = commentBody.replaceAll(UNSAFE_CHARACTERS_REGEX, "");
+    commentAuthor = commentAuthor.replaceAll(UNSAFE_CHARACTERS_REGEX, "").trim();
+    commentBody = commentBody.replaceAll(UNSAFE_CHARACTERS_REGEX, "").trim();
 
     String validationError = validateIncomingComment(commentAuthor, commentBody);
     if (validationError != null) {
@@ -62,10 +62,10 @@ public final class Comment {
     List<String> validationErrors = new ArrayList<String>();
     
     // Used in place of string.isBlank(), which is only available in Java 11
-    if (commentAuthor.length() == 0 || commentAuthor.chars().allMatch(Character::isWhitespace)) {
+    if (commentAuthor.length() == 0) {
       validationErrors.add("Please include a comment author (cannot be whitespace).");
     }
-    if (commentBody.length() == 0 || commentBody.chars().allMatch(Character::isWhitespace)) {
+    if (commentBody.length() == 0) {
       validationErrors.add("Please include a comment body (cannot be whitespace).");
     }
 

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -60,11 +60,12 @@ public final class Comment {
    */
   private static String validateIncomingComment(String commentAuthor, String commentBody) {
     List<String> validationErrors = new ArrayList<String>();
-
-    if (commentAuthor.isBlank()) {
+    
+    // Used in place of string.isBlank(), which is only available in Java 11
+    if (commentAuthor.length() == 0 || commentAuthor.chars().allMatch(Character::isWhitespace)) {
       validationErrors.add("Please include a comment author (cannot be whitespace).");
     }
-    if (commentBody.isBlank()) {
+    if (commentBody.length() == 0 || commentBody.chars().allMatch(Character::isWhitespace)) {
       validationErrors.add("Please include a comment body (cannot be whitespace).");
     }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/CommentBlobstoreServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/CommentBlobstoreServlet.java
@@ -44,12 +44,10 @@ public class CommentBlobstoreServlet extends HttpServlet {
   private Gson gson = new Gson();
 
   /** 
-   * Returns a URL that points to the image uploaded with a request. The URL is null if no file
-   * was uploaded or the file uploaded was not an image. If the file is not an image, the blobstore
-   * entry is removed to save space.
+   * Returns a URL that points to the image associated with a BlobKey.
    * 
-   * @param request
-   * @return Returns a URL that points to the image uploaded or null.
+   * @param blobKey
+   * @return Returns a URL that points to the image associated with the BlobKey.
    */
   public static String getUploadedImageURL(BlobKey blobKey) {
     ImagesService imagesService = ImagesServiceFactory.getImagesService();
@@ -65,7 +63,14 @@ public class CommentBlobstoreServlet extends HttpServlet {
       return imagesService.getServingUrl(options);
     }
   }
-
+  
+  /**
+   * Removes an uploaded image associated with a BlobKey.
+   * Removes the image from the ImageService as well as the Blobstore.
+   *
+   * @param blobKey
+   * @return Returns whether or not the uploaded image was removed successfully.
+   */
   public static boolean removeUploadedImage(BlobKey blobKey) {
     ImagesService imagesService = ImagesServiceFactory.getImagesService();
     try {
@@ -79,7 +84,16 @@ public class CommentBlobstoreServlet extends HttpServlet {
 
     return true;
   }
-
+  
+  /**
+   * Gets the BlobKey associated with an image uploaded with the request. Returns null
+   * if no file was uploaded or the file uploaded was not an image.
+   *
+   * @param request
+   * @param formInputName The property name of the image file from the request. This is also most
+   * likely the name of the input element for the file on the comment posting form.
+   * @return Returns the BlobKey for the uploaded image or null.
+   */
   public static BlobKey getUploadedImageBlobKey(HttpServletRequest request, String formInputName) {
     BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
     Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);

--- a/portfolio/src/main/java/com/google/sps/servlets/CommentBlobstoreServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/CommentBlobstoreServlet.java
@@ -19,9 +19,16 @@ import com.google.appengine.api.blobstore.BlobInfoFactory;
 import com.google.appengine.api.blobstore.BlobKey;
 import com.google.appengine.api.blobstore.BlobstoreService;
 import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+import com.google.appengine.api.images.ImagesService;
+import com.google.appengine.api.images.ImagesServiceFactory;
+import com.google.appengine.api.images.ServingUrlOptions;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -62,7 +69,8 @@ public class CommentBlobstoreServlet extends HttpServlet {
     // User submitted form without selecting a file, so we can't get a URL. (live server)
     // Or the user submitted a file but the file is not an image.
     BlobInfo blobInfo = new BlobInfoFactory().loadBlobInfo(blobKey);
-    if (blobInfo.getSize() == 0 || !blobInfo.getContentType().equals("image")) {
+    
+    if (blobInfo.getSize() == 0 || !blobInfo.getContentType().startsWith("image/")) {
       blobstoreService.delete(blobKey);
       return null;
     }

--- a/portfolio/src/main/java/com/google/sps/servlets/CommentBlobstoreServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/CommentBlobstoreServlet.java
@@ -1,0 +1,49 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/comment-blobstore")
+public class CommentBlobstoreServlet extends HttpServlet {
+
+  // Use constant redirect instead of client-supplied redirect URL 
+  // to avoid blobstore redirect spoofing.
+  public static String BLOBSTORE_URL_REDIRECT = "/comments";
+
+  private Gson gson = new Gson();
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
+    String uploadUrl = blobstoreService.createUploadUrl(BLOBSTORE_URL_REDIRECT);
+
+    JsonObject responseObject = new JsonObject();
+    responseObject.addProperty("uploadUrl", uploadUrl);
+    responseObject.addProperty("redirectUrl", BLOBSTORE_URL_REDIRECT);
+
+    response.setStatus(HttpServletResponse.SC_OK);
+    response.setContentType("application/json;");
+    response.getWriter().println(gson.toJson(responseObject));
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -14,6 +14,7 @@
 
 package com.google.sps.servlets;
 
+import com.google.appengine.api.blobstore.BlobKey;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
@@ -176,6 +177,10 @@ public class DataServlet extends HttpServlet {
       return;
     }
 
+    if (commentToDelete.getAttachedImageBlobKey() != null) {
+      CommentBlobstoreServlet.removeUploadedImage(
+          new BlobKey(commentToDelete.getAttachedImageBlobKey()));
+    }
     datastore.delete(commentKey);
 
     String commentJson = gson.toJson(commentToDelete);

--- a/portfolio/src/main/webapp/css/master.css
+++ b/portfolio/src/main/webapp/css/master.css
@@ -1,3 +1,8 @@
+.comment-image {
+  max-height: 200px;
+  max-width: 200px;
+}
+
 #fact-container {
   height: 75px;
   overflow-y: auto;

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -186,7 +186,11 @@
               <label for="comment-body">Comment</label>
               <textarea class="form-control comment-input" name="comment-body" maxlength="120" required></textarea>
             </div>
-            <button class="btn btn-primary" type="submit">Post</button>
+            <div class="form-group">
+              <label for="comment-body">Add Image (optional)</label>
+              <input type="file" class="form-control-file" name="commentPicture" accept=".gif,.jpg,.png"></input>
+            </div>
+            <button class="btn btn-primary" type="submit" name="submit-button">Post</button>
           </form>
         </div>
         <div class="card p-4 mb-4">

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -188,7 +188,7 @@
             </div>
             <div class="form-group">
               <label for="comment-body">Add Image (optional)</label>
-              <input type="file" class="form-control-file" name="commentPicture" accept=".gif,.jpg,.png"></input>
+              <input type="file" class="form-control-file" name="attachedImage" accept=".gif,.jpg,.png"></input>
             </div>
             <button class="btn btn-primary" type="submit" name="submit-button">Post</button>
           </form>

--- a/portfolio/src/main/webapp/js/comments.js
+++ b/portfolio/src/main/webapp/js/comments.js
@@ -145,6 +145,7 @@ function removeCommentsOnPage() {
  * @property {number} id
  * @property {number} timePosted Time the comment was posted in unix timestamp.
  * @property {string} posterId
+ * @property {string} attachedImageUrl
  */
 /**
  * Adds a comment to the comments section UI.
@@ -153,8 +154,51 @@ function removeCommentsOnPage() {
 function addCommentToPage(comment) {
   const commentContainer = document.getElementById("comment-container");
   
+  const commentRow = document.createElement("div");
+  commentRow.classList.add("row", "align-items-end", "border-bottom");
+  
+  const commentBodyElement = getCommentBodyElement(comment, commentRow);
+  if (comment.attachedImageUrl) {
+    const commentAttachedImage = getCommentAttachedImage(comment);
+    commentAttachedImage.classList.add("col-sm-3");
+
+    commentBodyElement.classList.add("col-sm-9");
+
+    commentRow.appendChild(commentAttachedImage);
+  }
+  
+  commentRow.appendChild(commentBodyElement);
+  commentContainer.appendChild(commentRow);
+}
+
+/**
+ * Creates the attached image element for a comment.
+ * @param {Comment} comment
+ * @return {Element} Returns the image element.
+ */
+function createCommentAttachedImage(comment) {
+  const attachedImage = document.createElement("img");
+  attachedImage.src = comment.attachedImageUrl;
+  attachedImage.classList.add("img-thumbnail", "comment-image", "my-2");
+
+  const imageContainer = document.createElement("div");
+  imageContainer.classList.add("d-flex", "justify-content-center");
+  imageContainer.appendChild(attachedImage);
+
+  return imageContainer;
+}
+
+/**
+ * Creates the body element of a comment. Includes the comment text, the time
+ * posted, and the author.
+ * @param {Comment} comment
+ * @param {Element} commentRow The comment element that contains all other
+ * comment elements.
+ * @return Returns the comment body element.
+ */
+function createCommentBodyElement(comment, commentRow) {
   const newComment = document.createElement("div");
-  newComment.classList.add("p-4", "border-bottom");
+  newComment.classList.add("p-4");
   newComment.innerText = comment.commentBody;
 
   const authorFooter = document.createElement("footer");
@@ -165,19 +209,30 @@ function addCommentToPage(comment) {
   if (commentAuthData && 
       commentAuthData.authorized && 
       commentAuthData.user.id === comment.posterId) {
-    const deleteButton = document.createElement("button");
-    deleteButton.classList.add("btn", "btn-muted", "btn-sm", "ml-2");
-    deleteButton.innerText = "Delete";
-    deleteButton.addEventListener(
-        "click", 
-        createCommentDeleter(comment.id, newComment));
-
+    const deleteButton = getCommentDeleteButton(comment, commentRow);
     authorFooter.appendChild(deleteButton);
   }
 
   newComment.appendChild(authorFooter);
 
-  commentContainer.appendChild(newComment);
+  return newComment;
+}
+
+/**
+ * Creates the delete button for a comment. 
+ * @param {Comment} comment
+ * @param {Element} commentRow
+ * @return Returns the comment delete button.
+ */
+function createCommentDeleteButton(comment, commentRow) {
+  const deleteButton = document.createElement("button");
+  deleteButton.classList.add("btn", "btn-muted", "btn-sm", "ml-2");
+  deleteButton.innerText = "Delete";
+  deleteButton.addEventListener(
+      "click", 
+      createCommentDeleter(comment.id, commentRow));
+
+  return deleteButton;
 }
 
 /**

--- a/portfolio/src/main/webapp/js/comments.js
+++ b/portfolio/src/main/webapp/js/comments.js
@@ -209,7 +209,7 @@ function postComment(event) {
 
   const requestOptions = {
     method: 'POST',
-    body: new FormData(commentForm)
+    body: new FormData(commentForm),
   };
 
   commentPostButton.disabled = true;


### PR DESCRIPTION
When an image is uploaded along with a comment, get the URL for the image and include it in the comment's datastore entry.